### PR TITLE
Bootstrap 4 - Added Classes option for Page elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,5 @@ LastBuild.log
 _ReSharper*
 .DS_Store
 src/PagedList.Mvc/Content/
+/src/X.PagedList.Mvc6/project.fragment.lock.json
+/src/X.PagedList.Mvc6.Example/project.fragment.lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -148,5 +148,3 @@ LastBuild.log
 _ReSharper*
 .DS_Store
 src/PagedList.Mvc/Content/
-/src/X.PagedList.Mvc6/project.fragment.lock.json
-/src/X.PagedList.Mvc6.Example/project.fragment.lock.json

--- a/src/X.PagedList.Mvc6/HtmlHelper.cs
+++ b/src/X.PagedList.Mvc6/HtmlHelper.cs
@@ -97,6 +97,10 @@ namespace PagedList.Mvc
             const int targetPageNumber = 1;
             var first = new TagBuilder("a");
             AppendHtml(first, string.Format(options.LinkToFirstPageFormat, targetPageNumber));
+
+            foreach (var c in options.PageClasses ?? Enumerable.Empty<string>())
+                first.AddCssClass(c);
+
             if (list.IsFirstPage)
                 return WrapInListItem(first, options, "PagedList-skipToFirst", "disabled");
 
@@ -110,6 +114,9 @@ namespace PagedList.Mvc
             var previous = new TagBuilder("a");
             AppendHtml(previous, string.Format(options.LinkToPreviousPageFormat, targetPageNumber));
             previous.Attributes["rel"] = "prev";
+
+            foreach (var c in options.PageClasses ?? Enumerable.Empty<string>())
+                previous.AddCssClass(c);
 
             if (!list.HasPreviousPage)
                 return WrapInListItem(previous, options, "PagedList-skipToPrevious", "disabled");
@@ -126,13 +133,13 @@ namespace PagedList.Mvc
             var page = i == list.PageNumber ? new TagBuilder("span") : new TagBuilder("a");
             SetInnerText(page, format(targetPageNumber));
 
+            foreach (var c in options.PageClasses ?? Enumerable.Empty<string>())
+                page.AddCssClass(c);
+
             if (i == list.PageNumber)
                 return WrapInListItem(page, options, "active");
 
             page.Attributes["href"] = generatePageUrl(targetPageNumber);
-
-            foreach (var c in options.PageClasses ?? Enumerable.Empty<string>())
-                page.AddCssClass(c);
 
             return WrapInListItem(page, options);
         }
@@ -143,6 +150,9 @@ namespace PagedList.Mvc
             var next = new TagBuilder("a");
             AppendHtml(next, string.Format(options.LinkToNextPageFormat, targetPageNumber));
             next.Attributes["rel"] = "next";
+
+            foreach (var c in options.PageClasses ?? Enumerable.Empty<string>())
+                next.AddCssClass(c);
 
             if (!list.HasNextPage)
                 return WrapInListItem(next, options, "PagedList-skipToNext", "disabled");
@@ -156,6 +166,9 @@ namespace PagedList.Mvc
             var targetPageNumber = list.PageCount;
             var last = new TagBuilder("a");
             AppendHtml(last, string.Format(options.LinkToLastPageFormat, targetPageNumber));
+
+            foreach (var c in options.PageClasses ?? Enumerable.Empty<string>())
+                last.AddCssClass(c);
 
             if (list.IsLastPage)
                 return WrapInListItem(last, options, "PagedList-skipToLast", "disabled");

--- a/src/X.PagedList.Mvc6/HtmlHelper.cs
+++ b/src/X.PagedList.Mvc6/HtmlHelper.cs
@@ -130,6 +130,10 @@ namespace PagedList.Mvc
                 return WrapInListItem(page, options, "active");
 
             page.Attributes["href"] = generatePageUrl(targetPageNumber);
+
+            foreach (var c in options.PageClasses ?? Enumerable.Empty<string>())
+                page.AddCssClass(c);
+
             return WrapInListItem(page, options);
         }
 

--- a/src/X.PagedList.Mvc6/PagedListRenderOptions.cs
+++ b/src/X.PagedList.Mvc6/PagedListRenderOptions.cs
@@ -43,7 +43,8 @@ namespace PagedList.Mvc
 			ContainerDivClasses = new [] { "pagination-container" };
 			UlElementClasses = new[] { "pagination" };
 			LiElementClasses = Enumerable.Empty<string>();
-		}
+            PageClasses = Enumerable.Empty<string>();
+        }
 
 		///<summary>
 		/// CSS Classes to append to the &lt;div&gt; element that wraps the paging control.
@@ -60,10 +61,15 @@ namespace PagedList.Mvc
 		///</summary>
 		public IEnumerable<string> LiElementClasses { get; set; }
 
-		///<summary>
-		/// Specifies a CSS class to append to the first list item in the pager. If null or whitespace is defined, no additional class is added to first list item in list.
-		///</summary>
-		public string ClassToApplyToFirstListItemInPager { get; set; }
+        ///<summary>
+        /// CSS Classes to append to every &lt;a&gt; or &lt;span&gt; element that represent each page in the paging control.
+        ///</summary>
+        public IEnumerable<string> PageClasses { get; set; }
+
+        ///<summary>
+        /// Specifies a CSS class to append to the first list item in the pager. If null or whitespace is defined, no additional class is added to first list item in list.
+        ///</summary>
+        public string ClassToApplyToFirstListItemInPager { get; set; }
 
 		///<summary>
 		/// Specifies a CSS class to append to the last list item in the pager. If null or whitespace is defined, no additional class is added to last list item in list.


### PR DESCRIPTION
Per Bootstrap v4 Alpha Migration guide:
- Explicit classes (.page-item, .page-link) are now required on the descendants of .paginations

Added a new PageClasses property to PagedListRenderOptions and added classes from the property in HtmlHelper.

Example usage:
```
new PagedListRenderOptions { 
    LiElementClasses = new[] { "page-item" }, 
    PageClasses = new[] { "page-link" } 
}
```