### PR TITLE
Add overload for ToPagedListAsync

### DIFF
--- a/X.PagedList.Tests/AsyncPagedListExtensionsTheories.cs
+++ b/X.PagedList.Tests/AsyncPagedListExtensionsTheories.cs
@@ -19,7 +19,22 @@ namespace X.PagedList.Tests
             Assert.Equal(pageNumber, pagedBlogs.PageNumber);
             Assert.Equal(pageSize, pagedBlogs.PageSize);
         }
-        
+
+        [Theory]
+        [InlineData(1, 1)]
+        [InlineData(2, 2)]
+        [InlineData(3, 3)]
+        public async Task ToListAsync_ForQueryable_WithoutPageNumber_Works(int pageSize, int expectedCount)
+        {
+            int? pageNumber = null;
+            var blogs = BuildBlogList();
+            var pagedBlogs = await blogs.ToPagedListAsync(pageNumber, pageSize);
+
+            Assert.Equal(expectedCount, pagedBlogs.Count);
+            Assert.Equal(1, pagedBlogs.PageNumber);
+            Assert.Equal(pageSize, pagedBlogs.PageSize);
+        }
+
         private static IQueryable<Blog> BuildBlogList()
         {
             return new List<Blog>

--- a/X.PagedList/AsyncPagedListExtensions.cs
+++ b/X.PagedList/AsyncPagedListExtensions.cs
@@ -47,5 +47,19 @@ namespace X.PagedList
         {
             return AsyncPagedList<T>.CreateAsync(superset, pageNumber, pageSize);
         }
+
+        /// <summary>
+        /// Async creates a subset of this collection of objects that can be individually accessed by index (defaulting to the first page) and containing metadata about the collection of objects the subset was created from.
+        /// </summary>
+        /// <typeparam name="T">The type of object the collection should contain.</typeparam>
+        /// <typeparam name="TKey">Type For Compare</typeparam>
+        /// <param name="pageNumber">The one-based index of the subset of objects to be contained by this instance, defaulting to the first page.</param>
+        /// <param name="pageSize">The maximum size of any individual subset.</param>
+        /// <returns>A subset of this collection of objects that can be individually accessed by index and containing metadata about the collection of objects the subset was created from.</returns>
+        /// <seealso cref="PagedList{T}"/>
+        public static Task<IPagedList<T>> ToPagedListAsync<T>(this IQueryable<T> superset, int? pageNumber, int pageSize)
+        {
+            return superset.ToPagedListAsync(pageNumber ?? 1, pageSize);
+        }
     }
 }


### PR DESCRIPTION
This handles null pageNumbers, so it can default to the first page for us and save repetition